### PR TITLE
Fix ubuntu and debian installs.

### DIFF
--- a/.docker/debian/oldstable/Dockerfile
+++ b/.docker/debian/oldstable/Dockerfile
@@ -1,0 +1,72 @@
+FROM debian:oldstable
+
+# container env needed by systemd
+ENV DEBIAN_FRONTEND="noninteractive" container="docker"
+
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y \
+	apt-utils \
+	curl \
+	locales \
+	lsb-release \
+	net-tools \
+	openssh-server \
+	python-pip \
+	python2.7 \
+	sudo \
+	systemd \
+ && pip install --upgrade pip \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+ && login_shell=$(command -v bash) \
+ && if ! getent passwd <%= @username %>; then \
+      useradd -u 9000 -d /home/<%= @username %> -m -s "${login_shell}" -p '*' <%= @username %>; \
+    fi \
+ && echo "<%= @username %> ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/kitchen \
+ && chmod 440 /etc/sudoers.d/kitchen \
+ && echo "Defaults !requiretty" >> /etc/sudoers \
+ && mkdir -p /home/<%= @username %>/.ssh \
+ && chown -R <%= @username %> /home/<%= @username %>/.ssh \
+ && chmod 0700 /home/<%= @username %>/.ssh \
+ && echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys \
+ && chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys \
+ && chmod 0600 /home/<%= @username %>/.ssh/authorized_keys \
+ && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen \
+ && cd /lib/systemd/system/sysinit.target.wants/; ls | grep -v systemd-tmpfiles-setup | xargs rm -f $1 \
+ && rm -f /lib/systemd/system/multi-user.target.wants/* \
+ && rm -f /etc/systemd/system/*.wants/* \
+ && rm -f /lib/systemd/system/local-fs.target.wants/* \
+ && rm -f /lib/systemd/system/sockets.target.wants/*udev* \
+ && rm -f /lib/systemd/system/sockets.target.wants/*initctl* \
+ && rm -f /lib/systemd/system/basic.target.wants/* \
+ && rm -f /lib/systemd/system/anaconda.target.wants/*  \
+ && rm -f /lib/systemd/system/plymouth* \
+ && rm -f /lib/systemd/system/systemd-update-utmp* \
+ && sed -ri 's/^#?UsePAM\s+.*/UsePAM no/' /etc/ssh/sshd_config \
+ && sed -ri 's/^#?PubkeyAuthentication\s+.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config \
+ && sed -ri 's/^#?UsePrivilegeSeparation\s+.*/UsePrivilegeSeparation no/' /etc/ssh/sshd_config \
+ && echo "UseDNS=no" >> /etc/ssh/sshd_config \
+ && systemctl set-default multi-user.target \
+ && ln -s /lib/systemd/system/systemd-journald.service /etc/systemd/system/multi-user.target.wants/systemd-journald.service \
+ && ln -s /lib/systemd/system/ssh.service /etc/systemd/system/multi-user.target.wants/ssh.service \
+ && echo $'[Unit]\
+\nDescription=Finish boot up\
+\nAfter=ssh.service\
+\n\
+\n[Service]\
+\nType=oneshot\
+\nRemainAfterExit=yes\
+\nExecStartPre=/bin/sleep 3s\
+\nExecStart=/bin/rm -f /run/nologin\
+\n\
+\n[Install]\
+\nWantedBy=default.target' >> /etc/systemd/system/FinishBootUp.service \
+ && ln -s /etc/systemd/system/FinishBootUp.service /etc/systemd/system/multi-user.target.wants/FinishBootUp.service
+
+# Graceful systemd shutdown
+STOPSIGNAL SIGRTMIN+3
+
+EXPOSE 22
+
+VOLUME [ "/sys/fs/cgroup" ]

--- a/.docker/debian/stable/Dockerfile
+++ b/.docker/debian/stable/Dockerfile
@@ -1,0 +1,72 @@
+FROM debian:latest
+
+# container env needed by systemd
+ENV DEBIAN_FRONTEND="noninteractive" container="docker"
+
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y \
+	apt-utils \
+	curl \
+	locales \
+	lsb-release \
+	net-tools \
+	openssh-server \
+	python-pip \
+	python2.7 \
+	sudo \
+	systemd \
+ && pip install --upgrade pip \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+ && login_shell=$(command -v bash) \
+ && if ! getent passwd <%= @username %>; then \
+      useradd -u 9000 -d /home/<%= @username %> -m -s "${login_shell}" -p '*' <%= @username %>; \
+    fi \
+ && echo "<%= @username %> ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/kitchen \
+ && chmod 440 /etc/sudoers.d/kitchen \
+ && echo "Defaults !requiretty" >> /etc/sudoers \
+ && mkdir -p /home/<%= @username %>/.ssh \
+ && chown -R <%= @username %> /home/<%= @username %>/.ssh \
+ && chmod 0700 /home/<%= @username %>/.ssh \
+ && echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys \
+ && chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys \
+ && chmod 0600 /home/<%= @username %>/.ssh/authorized_keys \
+ && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen \
+ && cd /lib/systemd/system/sysinit.target.wants/; ls | grep -v systemd-tmpfiles-setup | xargs rm -f $1 \
+ && rm -f /lib/systemd/system/multi-user.target.wants/* \
+ && rm -f /etc/systemd/system/*.wants/* \
+ && rm -f /lib/systemd/system/local-fs.target.wants/* \
+ && rm -f /lib/systemd/system/sockets.target.wants/*udev* \
+ && rm -f /lib/systemd/system/sockets.target.wants/*initctl* \
+ && rm -f /lib/systemd/system/basic.target.wants/* \
+ && rm -f /lib/systemd/system/anaconda.target.wants/*  \
+ && rm -f /lib/systemd/system/plymouth* \
+ && rm -f /lib/systemd/system/systemd-update-utmp* \
+ && sed -ri 's/^#?UsePAM\s+.*/UsePAM no/' /etc/ssh/sshd_config \
+ && sed -ri 's/^#?PubkeyAuthentication\s+.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config \
+ && sed -ri 's/^#?UsePrivilegeSeparation\s+.*/UsePrivilegeSeparation no/' /etc/ssh/sshd_config \
+ && echo "UseDNS=no" >> /etc/ssh/sshd_config \
+ && systemctl set-default multi-user.target \
+ && ln -s /lib/systemd/system/systemd-journald.service /etc/systemd/system/multi-user.target.wants/systemd-journald.service \
+ && ln -s /lib/systemd/system/ssh.service /etc/systemd/system/multi-user.target.wants/ssh.service \
+ && echo $'[Unit]\
+\nDescription=Finish boot up\
+\nAfter=ssh.service\
+\n\
+\n[Service]\
+\nType=oneshot\
+\nRemainAfterExit=yes\
+\nExecStartPre=/bin/sleep 3s\
+\nExecStart=/bin/rm -f /run/nologin\
+\n\
+\n[Install]\
+\nWantedBy=default.target' >> /etc/systemd/system/FinishBootUp.service \
+ && ln -s /etc/systemd/system/FinishBootUp.service /etc/systemd/system/multi-user.target.wants/FinishBootUp.service
+
+# Graceful systemd shutdown
+STOPSIGNAL SIGRTMIN+3
+
+EXPOSE 22
+
+VOLUME [ "/sys/fs/cgroup" ]

--- a/.docker/fedora/latest/Dockerfile
+++ b/.docker/fedora/latest/Dockerfile
@@ -1,0 +1,75 @@
+FROM fedora:latest
+
+# container env needed by systemd
+ENV container="docker"
+
+RUN dnf clean all \
+ && dnf makecache \
+ && dnf install -y \
+	curl \
+	findutils \
+	gcc \
+	glibc-langpack-en.x86_64  \
+	libffi-devel \
+	net-tools \
+	openssh-server \
+	openssl-devel \
+	python2-devel \
+	python2-pip \
+	redhat-lsb \
+	redhat-rpm-config \
+	sudo \
+	systemd \
+ && pip install --upgrade pip \
+ && dnf clean all \
+ && login_shell=$(command -v bash) \
+ && if ! getent passwd <%= @username %>; then \
+      useradd -u 9000 -d /home/<%= @username %> -m -s "${login_shell}" -p '*' <%= @username %>; \
+    fi \
+ && echo "<%= @username %> ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/kitchen \
+ && chmod 440 /etc/sudoers.d/kitchen \
+ && echo "Defaults !requiretty" >> /etc/sudoers \
+ && mkdir -p /home/<%= @username %>/.ssh \
+ && chown -R <%= @username %> /home/<%= @username %>/.ssh \
+ && chmod 0700 /home/<%= @username %>/.ssh \
+ && echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys \
+ && chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys \
+ && chmod 0600 /home/<%= @username %>/.ssh/authorized_keys \
+ && export LANG="en_US.UTF-8" && echo "LANG=\"en_US.UTF-8\"" > /etc/locale.conf \
+ && cd /lib/systemd/system/sysinit.target.wants/; ls | grep -v systemd-tmpfiles-setup | xargs rm -f $1 \
+ && rm -f /lib/systemd/system/multi-user.target.wants/* \
+ && rm -f /etc/systemd/system/*.wants/* \
+ && rm -f /lib/systemd/system/local-fs.target.wants/* \
+ && rm -f /lib/systemd/system/sockets.target.wants/*udev* \
+ && rm -f /lib/systemd/system/sockets.target.wants/*initctl* \
+ && rm -f /lib/systemd/system/basic.target.wants/* \
+ && rm -f /lib/systemd/system/anaconda.target.wants/*  \
+ && rm -f /lib/systemd/system/plymouth* \
+ && rm -f /lib/systemd/system/systemd-update-utmp* \
+ && sed -ri 's/^#?UsePAM\s+.*/UsePAM no/' /etc/ssh/sshd_config \
+ && sed -ri 's/^#?PubkeyAuthentication\s+.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config \
+ && sed -ri 's/^#?UsePrivilegeSeparation\s+.*/UsePrivilegeSeparation no/' /etc/ssh/sshd_config \
+ && echo "UseDNS=no" >> /etc/ssh/sshd_config \
+ && systemctl set-default multi-user.target \
+ && ln -s /lib/systemd/system/systemd-journald.service /etc/systemd/system/multi-user.target.wants/systemd-journald.service \
+ && ln -s /lib/systemd/system/sshd.service /etc/systemd/system/multi-user.target.wants/sshd.service \
+ && echo $'[Unit]\
+\nDescription=Finish boot up\
+\nAfter=sshd.service\
+\n\
+\n[Service]\
+\nType=oneshot\
+\nRemainAfterExit=yes\
+\nExecStartPre=/bin/sleep 3s\
+\nExecStart=/bin/rm -f /run/nologin\
+\n\
+\n[Install]\
+\nWantedBy=default.target' >> /etc/systemd/system/FinishBootUp.service \
+ && ln -s /etc/systemd/system/FinishBootUp.service /etc/systemd/system/multi-user.target.wants/FinishBootUp.service
+
+# Graceful systemd shutdown
+STOPSIGNAL SIGRTMIN+3
+
+EXPOSE 22
+
+VOLUME [ "/sys/fs/cgroup" ]

--- a/.docker/opensuse/tumbleweed/Dockerfile
+++ b/.docker/opensuse/tumbleweed/Dockerfile
@@ -1,0 +1,79 @@
+FROM opensuse/amd64:tumbleweed
+
+# container env needed by systemd
+ENV container="docker"
+
+RUN zypper --non-interactive --gpg-auto-import-keys ref \
+ && zypper --non-interactive --gpg-auto-import-keys install \
+	'rubygem(bundler)' \
+	curl \
+	findutils \
+	gcc \
+	git \
+	glibc-locale  \
+	libffi-devel \
+	libopenssl-devel \
+	lsb \
+	lsb-release \
+	net-tools \
+	net-tools-deprecated \
+	openssh \
+	python-devel \
+	python2-pip \
+	sudo \
+	system-group-wheel \
+	systemd \
+ && pip install --upgrade pip \
+ && zypper cc --all \
+ && login_shell=$(command -v bash) \
+ && if ! getent passwd <%= @username %>; then \
+      useradd -u 9000 -d /home/<%= @username %> -m -s "${login_shell}" -p '*' <%= @username %>; \
+    fi \
+ && echo "<%= @username %> ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/kitchen \
+ && chmod 440 /etc/sudoers.d/kitchen \
+ && echo "Defaults !requiretty" >> /etc/sudoers \
+ && mkdir -p /home/<%= @username %>/.ssh \
+ && chown -R <%= @username %> /home/<%= @username %>/.ssh \
+ && chmod 0700 /home/<%= @username %>/.ssh \
+ && echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys \
+ && chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys \
+ && chmod 0600 /home/<%= @username %>/.ssh/authorized_keys \
+ && export LANG="en_US.UTF-8" && echo "LANG=\"en_US.UTF-8\"" > /etc/locale.conf \
+ && cd /usr/lib/systemd/system/sysinit.target.wants/; ls | grep -v systemd-tmpfiles-setup | xargs rm -f $1 \
+ && rm -f /usr/lib/systemd/system/multi-user.target.wants/* \
+ && rm -f /etc/systemd/system/*.wants/* \
+ && rm -f /usr/lib/systemd/system/local-fs.target.wants/* \
+ && rm -f /usr/lib/systemd/system/sockets.target.wants/*udev* \
+ && rm -f /usr/lib/systemd/system/sockets.target.wants/*initctl* \
+ && rm -f /usr/lib/systemd/system/basic.target.wants/* \
+ && rm -f /usr/lib/systemd/system/anaconda.target.wants/*  \
+ && rm -f /usr/lib/systemd/system/plymouth* \
+ && rm -f /usr/lib/systemd/system/systemd-update-utmp* \
+ && sed -ri 's/^#?UsePAM\s+.*/UsePAM no/' /etc/ssh/sshd_config \
+ && sed -ri 's/^#?PubkeyAuthentication\s+.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config \
+ && sed -ri 's/^#?UsePrivilegeSeparation\s+.*/UsePrivilegeSeparation no/' /etc/ssh/sshd_config \
+ && echo "UseDNS=no" >> /etc/ssh/sshd_config \
+ && systemctl set-default multi-user.target \
+ && ln -s /usr/lib/systemd/system/systemd-journald.service /etc/systemd/system/multi-user.target.wants/systemd-journald.service \
+ && ln -s /usr/lib/systemd/system/sshd.service /etc/systemd/system/multi-user.target.wants/sshd.service \
+ && echo $'[Unit]\
+\nDescription=Finish boot up\
+\nAfter=sshd.service\
+\n\
+\n[Service]\
+\nType=oneshot\
+\nRemainAfterExit=yes\
+\nExecStartPre=/bin/sleep 3s\
+\nExecStart=/bin/rm -f /run/nologin\
+\n\
+\n[Install]\
+\nWantedBy=default.target' >> /etc/systemd/system/FinishBootUp.service \
+ && ln -s /etc/systemd/system/FinishBootUp.service /etc/systemd/system/multi-user.target.wants/FinishBootUp.service \
+ && ln -sf /usr/bin/pip2 /etc/alternatives/pip
+
+# Graceful systemd shutdown
+STOPSIGNAL SIGRTMIN+3
+
+EXPOSE 22
+
+VOLUME [ "/sys/fs/cgroup" ]

--- a/.docker/ubuntu/rolling/Dockerfile
+++ b/.docker/ubuntu/rolling/Dockerfile
@@ -1,0 +1,72 @@
+FROM ubuntu:rolling
+
+# container env needed by systemd
+ENV DEBIAN_FRONTEND="noninteractive" container="docker"
+
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y \
+	apt-utils \
+	curl \
+	locales \
+	lsb-release \
+	net-tools \
+	openssh-server \
+	python-pip \
+	python2.7 \
+	sudo \
+	systemd \
+ && pip install --upgrade pip \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+ && login_shell=$(command -v bash) \
+ && if ! getent passwd <%= @username %>; then \
+      useradd -u 9000 -d /home/<%= @username %> -m -s "${login_shell}" -p '*' <%= @username %>; \
+    fi \
+ && echo "<%= @username %> ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/kitchen \
+ && chmod 440 /etc/sudoers.d/kitchen \
+ && echo "Defaults !requiretty" >> /etc/sudoers \
+ && mkdir -p /home/<%= @username %>/.ssh \
+ && chown -R <%= @username %> /home/<%= @username %>/.ssh \
+ && chmod 0700 /home/<%= @username %>/.ssh \
+ && echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys \
+ && chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys \
+ && chmod 0600 /home/<%= @username %>/.ssh/authorized_keys \
+ && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen \
+ && cd /lib/systemd/system/sysinit.target.wants/; ls | grep -v systemd-tmpfiles-setup | xargs rm -f $1 \
+ && rm -f /lib/systemd/system/multi-user.target.wants/* \
+ && rm -f /etc/systemd/system/*.wants/* \
+ && rm -f /lib/systemd/system/local-fs.target.wants/* \
+ && rm -f /lib/systemd/system/sockets.target.wants/*udev* \
+ && rm -f /lib/systemd/system/sockets.target.wants/*initctl* \
+ && rm -f /lib/systemd/system/basic.target.wants/* \
+ && rm -f /lib/systemd/system/anaconda.target.wants/*  \
+ && rm -f /lib/systemd/system/plymouth* \
+ && rm -f /lib/systemd/system/systemd-update-utmp* \
+ && sed -ri 's/^#?UsePAM\s+.*/UsePAM no/' /etc/ssh/sshd_config \
+ && sed -ri 's/^#?PubkeyAuthentication\s+.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config \
+ && sed -ri 's/^#?UsePrivilegeSeparation\s+.*/UsePrivilegeSeparation no/' /etc/ssh/sshd_config \
+ && echo "UseDNS=no" >> /etc/ssh/sshd_config \
+ && systemctl set-default multi-user.target \
+ && ln -s /lib/systemd/system/systemd-journald.service /etc/systemd/system/multi-user.target.wants/systemd-journald.service \
+ && ln -s /lib/systemd/system/ssh.service /etc/systemd/system/multi-user.target.wants/ssh.service \
+ && echo $'[Unit]\
+\nDescription=Finish boot up\
+\nAfter=ssh.service\
+\n\
+\n[Service]\
+\nType=oneshot\
+\nRemainAfterExit=yes\
+\nExecStartPre=/bin/sleep 3s\
+\nExecStart=/bin/rm -f /run/nologin\
+\n\
+\n[Install]\
+\nWantedBy=default.target' >> /etc/systemd/system/FinishBootUp.service \
+ && ln -s /etc/systemd/system/FinishBootUp.service /etc/systemd/system/multi-user.target.wants/FinishBootUp.service
+
+# Graceful systemd shutdown
+STOPSIGNAL SIGRTMIN+3
+
+EXPOSE 22
+
+VOLUME [ "/sys/fs/cgroup" ]

--- a/.docker/ubuntu/stable/Dockerfile
+++ b/.docker/ubuntu/stable/Dockerfile
@@ -1,0 +1,72 @@
+FROM ubuntu:latest
+
+# container env needed by systemd
+ENV DEBIAN_FRONTEND="noninteractive" container="docker"
+
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y \
+	apt-utils \
+	curl \
+	locales \
+	lsb-release \
+	net-tools \
+	openssh-server \
+	python-pip \
+	python2.7 \
+	sudo \
+	systemd \
+ && pip install --upgrade pip \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+ && login_shell=$(command -v bash) \
+ && if ! getent passwd <%= @username %>; then \
+      useradd -u 9000 -d /home/<%= @username %> -m -s "${login_shell}" -p '*' <%= @username %>; \
+    fi \
+ && echo "<%= @username %> ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/kitchen \
+ && chmod 440 /etc/sudoers.d/kitchen \
+ && echo "Defaults !requiretty" >> /etc/sudoers \
+ && mkdir -p /home/<%= @username %>/.ssh \
+ && chown -R <%= @username %> /home/<%= @username %>/.ssh \
+ && chmod 0700 /home/<%= @username %>/.ssh \
+ && echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys \
+ && chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys \
+ && chmod 0600 /home/<%= @username %>/.ssh/authorized_keys \
+ && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen \
+ && cd /lib/systemd/system/sysinit.target.wants/; ls | grep -v systemd-tmpfiles-setup | xargs rm -f $1 \
+ && rm -f /lib/systemd/system/multi-user.target.wants/* \
+ && rm -f /etc/systemd/system/*.wants/* \
+ && rm -f /lib/systemd/system/local-fs.target.wants/* \
+ && rm -f /lib/systemd/system/sockets.target.wants/*udev* \
+ && rm -f /lib/systemd/system/sockets.target.wants/*initctl* \
+ && rm -f /lib/systemd/system/basic.target.wants/* \
+ && rm -f /lib/systemd/system/anaconda.target.wants/*  \
+ && rm -f /lib/systemd/system/plymouth* \
+ && rm -f /lib/systemd/system/systemd-update-utmp* \
+ && sed -ri 's/^#?UsePAM\s+.*/UsePAM no/' /etc/ssh/sshd_config \
+ && sed -ri 's/^#?PubkeyAuthentication\s+.*/PubkeyAuthentication yes/' /etc/ssh/sshd_config \
+ && sed -ri 's/^#?UsePrivilegeSeparation\s+.*/UsePrivilegeSeparation no/' /etc/ssh/sshd_config \
+ && echo "UseDNS=no" >> /etc/ssh/sshd_config \
+ && systemctl set-default multi-user.target \
+ && ln -s /lib/systemd/system/systemd-journald.service /etc/systemd/system/multi-user.target.wants/systemd-journald.service \
+ && ln -s /lib/systemd/system/ssh.service /etc/systemd/system/multi-user.target.wants/ssh.service \
+ && echo $'[Unit]\
+\nDescription=Finish boot up\
+\nAfter=ssh.service\
+\n\
+\n[Service]\
+\nType=oneshot\
+\nRemainAfterExit=yes\
+\nExecStartPre=/bin/sleep 3s\
+\nExecStart=/bin/rm -f /run/nologin\
+\n\
+\n[Install]\
+\nWantedBy=default.target' >> /etc/systemd/system/FinishBootUp.service \
+ && ln -s /etc/systemd/system/FinishBootUp.service /etc/systemd/system/multi-user.target.wants/FinishBootUp.service
+
+# Graceful systemd shutdown
+STOPSIGNAL SIGRTMIN+3
+
+EXPOSE 22
+
+VOLUME [ "/sys/fs/cgroup" ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
 ansible.cfg
 *.retry
+
+# Bundler
+.bundle
+vendor
+Gemfile.lock
+
+# Ruby
+.ruby-version
+
+# Test-kitchen
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,128 @@
+---
+driver:
+  name: docker
+  use_sudo: false
+
+provisioner:
+  # name of the host
+  hosts: test-kitchen
+  # use an ansible playbook to provision our server
+  name: ansible_playbook
+  ansible_verbose: true
+  ansible_verbosity: 4
+  require_ansible_repo: false
+  require_ansible_omnibus: true
+  ansible_version: 2.4.2
+  require_chef_for_busser: false
+  sudo: True
+  sudo_command: sudo -E -H
+  idempotency_test: true
+  extra_vars:
+    pwsh_install_omi: True
+    pwsh_install_azure_cli: True
+
+
+transport:
+  max_ssh_sessions: 6
+
+platforms:
+  - name: ubuntu-rolling
+    driver_config:
+      run_command: /lib/systemd/systemd
+      dockerfile: .docker/ubuntu/rolling/Dockerfile
+      platform: ubuntu
+      instance_name: test-role-ansible-powershell-ubuntu-rolling
+      cap_add:
+        - SYS_ADMIN
+      volume:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      run_options:
+        tmpfs:
+          - /run
+          - /run/lock
+
+  - name: ubuntu-stable
+    driver_config:
+      run_command: /lib/systemd/systemd
+      dockerfile: .docker/ubuntu/stable/Dockerfile
+      platform: ubuntu
+      instance_name: test-role-ansible-powershell-ubuntu-stable
+      cap_add:
+        - SYS_ADMIN
+      volume:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      run_options:
+        tmpfs:
+          - /run
+          - /run/lock
+
+  - name: debian-stable
+    driver_config:
+      run_command: /lib/systemd/systemd
+      dockerfile: .docker/debian/stable/Dockerfile
+      platform: debian
+      instance_name: test-role-ansible-powershell-debian-stable
+      cap_add:
+        - SYS_ADMIN
+      volume:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      run_options:
+        tmpfs:
+          - /run
+          - /run/lock
+
+  - name: debian-oldstable
+    driver_config:
+      run_command: /lib/systemd/systemd
+      dockerfile: .docker/debian/oldstable/Dockerfile
+      platform: debian
+      instance_name: test-role-ansible-powershell-debian-oldstable
+      cap_add:
+        - SYS_ADMIN
+      volume:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      run_options:
+        tmpfs:
+          - /run
+          - /run/lock
+
+#  - name: fedora-latest
+#    driver_config:
+#      run_command: /lib/systemd/systemd
+#      dockerfile: .docker/fedora/latest/Dockerfile
+#      platform: fedora
+#      instance_name: test-role-ansible-powershell-fedora-latest
+#      cap_add:
+#        - SYS_ADMIN
+#      volume:
+#        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#      run_options:
+#        tmpfs:
+#          - /run
+#          - /run/lock
+#
+#  - name: opensuse-tumbleweed
+#    driver_config:
+#      run_command: /usr/lib/systemd/systemd
+#      dockerfile: .docker/opensuse/tumbleweed/Dockerfile
+#      platform: opensuse
+#      instance_name: test-role-ansible-powershell-opensuse-tumbleweed
+#      cap_add:
+#        - SYS_ADMIN
+#      volume:
+#        - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#      run_options:
+#        tmpfs:
+#          - /run
+#          - /run/lock
+
+verifier:
+  name: serverspec
+  sudo_path: True
+
+suites:
+  # suites found at /test/integration/$test-name
+  - name: default
+    verifier:
+      patterns:
+        - roles/ansible-powershell/test/integration/default/serverspec/*_spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'test-kitchen'
+gem 'kitchen-ansible'
+gem 'kitchen-vagrant'
+gem 'kitchen-docker'
+gem 'kitchen-verifier-serverspec'

--- a/tasks/os_Debian.yml
+++ b/tasks/os_Debian.yml
@@ -2,34 +2,213 @@
 # tasks file for powershell
 
 
+- name: Set repo url
+  set_fact:
+    pwsh_repo: "{{ item.url }}"
+  when:
+    - ansible_lsb.codename == item.codename
+  with_items:
+    - codename: artful
+      url: https://packages.microsoft.com/ubuntu/17.04/prod zesty
+    - codename: zesty
+      url: https://packages.microsoft.com/ubuntu/17.04/prod zesty
+    - codename: xenial
+      url: https://packages.microsoft.com/ubuntu/16.04/prod xenial
+    - codename: trusty
+      url: https://packages.microsoft.com/ubuntu/14.04/prod trusty
+    - codename: jessie
+      url: https://packages.microsoft.com/repos/microsoft-debian-jessie-prod jessie
+    - codename: stretch
+      url: https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch
+
+- name: install pre-requistes
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - gawk
+    - apt-transport-https
+
 - name: set gpg key
   apt_key:
     url: "https://packages.microsoft.com/keys/microsoft.asc"
     state: present
 
-- name: add repository
+- name: install azure-cli gpg key
+  apt_key:
+    keyserver: packages.microsoft.com
+    id: 52E16F86FEE04B979B07E28DB02C46DF417A0893
+    state: present
+  when:
+    - pwsh_install_azure_cli|default(false)
+
+- name: add pwsh repository
   apt_repository:
-    repo: "deb [arch=amd64] https://packages.microsoft.com/ubuntu/{{ansible_distribution_version}}/prod {{ ansible_distribution_release }} main"
+    repo: "deb [arch=amd64] {{ pwsh_repo }} main"
     filename: microsoft.powershell
     state: present
     update_cache: yes
 
-- name: add repository
+- name: remove outdated pwsh repository
   apt_repository:
-    repo: "deb https://packages.microsoft.com/ubuntu/{{ansible_distribution_version}}/prod {{ ansible_distribution_release }} main"
+    repo: "deb {{ pwsh_repo }} main"
     filename: microsoft.powershell
     state: absent
-    update_cache: yes    
+    update_cache: yes
+
+- name: add azure-cli repository
+  apt_repository:
+    repo: "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main"
+    filename: microsoft.azure-cli
+    state: present
+    update_cache: yes
+  when:
+    - pwsh_install_azure_cli|default(false)
 
 - name: install powershell
   apt:
     name: powershell
     state: latest
 
-- name: omi and remoting
+- name: install azure-cli
+  apt:
+    name: azure-cli
+    state: latest
+  when:
+    - pwsh_install_azure_cli|default(false)
+
+- name: register azure modules existence
+  shell: pwsh -c "Get-Module -ListAvailable" | awk 'BEGIN{cnt=0} /Azure/{ cnt++ } END{if (cnt >= 1) {print "1"} else {print "0"}}'
+  register: azure_pwsh_module
+  changed_when: false
+
+- name: update pwsh help
+  command: "pwsh -noni -c 'Update-Help'"
+  register: pwsh_update
+  changed_when:
+    - pwsh_update.stdout != ""
+
+- name: install pwsh azure modules
+  command: "{{ item }}"
+  with_items:
+    - "pwsh -noni -c 'Install-Module -Force AzureRM.Netcore'"
+    - "pwsh -noni -c 'Import-Module AzureRM.Netcore'"
+    - "pwsh -noni -c 'Import-Module AzureRM.Profile.Netcore'"
+  when:
+    - azure_pwsh_module.stdout == "0"
+    - pwsh_install_azure_cli|default(false)
+
+- name: register openssl version
+  shell: openssl version | awk '{ version=$2; gsub(/[A-z]/,"",version); print version }'
+  register: openssl_version
+  changed_when: false
+
+- debug:
+    var: openssl_version
+
+- name: set omi ssl version to 1.1.0
+  set_fact:
+    omi_ssl_version: "ssl_110"
+  when:
+    - openssl_version.stdout | version_compare('1.1.0','>=')
+
+- name: set omi ssl version to 1.0.0
+  set_fact:
+    omi_ssl_version: "ssl_100"
+  when:
+    - openssl_version.stdout | version_compare('1.0.0','>=')
+    - openssl_version.stdout | version_compare('1.1.0','<')
+
+- name: set omi ssl version to 0.9.8
+  set_fact:
+    omi_ssl_version: "ssl_098"
+  when:
+    - openssl_version.stdout | version_compare('1.0.0','<')
+
+- name: Check if omi is installed
+  command: warn=no dpkg-query -s omi
+  register: omi_is_installed
+  ignore_errors: true
+  changed_when: false
+
+- name: register omi releases
+  shell: curl -sL https://github.com/Microsoft/omi/releases | gawk -v ssl_version={{ omi_ssl_version }} '/<a href=(.*deb).*/{if ($0 ~ ssl_version) { match($0,"<a href=.(.*deb).*",matches); print matches[1] }}'
+  register: omi_releases
+  when:
+    - pwsh_install_omi|default(false)
+    - ansible_lsb.codename != "xenial"
+    - omi_is_installed.rc == 1
+
+- name: download latest omi release
+  get_url:
+    url: "https://github.com{{ omi_releases.stdout_lines[0] }}"
+    dest: /tmp/omi.deb
+  register: omi_download
+  when:
+    - pwsh_install_omi|default(false)
+    - omi_is_installed.rc == 1
+    - ansible_lsb.codename != "xenial"
+
+- name: install omi
+  apt:
+    deb: "/tmp/omi.deb"
+  when:
+    - pwsh_install_omi|default(false)
+    - omi_is_installed.rc == 1
+    - omi_download.changed
+    - ansible_lsb.codename != "xenial"
+
+- name: clean omi download
+  file:
+    path: /tmp/omi.deb
+    state: absent
+
+- name: Check if omi psrp server is installed
+  command: warn=no dpkg-query -s omi-psrp-server
+  register: omi_psrp_server_is_installed
+  ignore_errors: true
+  changed_when: false
+
+- name: register omi psrp server releases
+  shell: curl -sL https://github.com/PowerShell/psl-omi-provider/releases | gawk '/<a href=(.*deb).*/{ match($0,"<a href=\"(.*deb).*",matches); print matches[1] }'
+  register: omi_psrp_server_releases
+  changed_when: false
+  when:
+    - pwsh_install_omi|default(false)
+    - ansible_lsb.codename != "xenial"
+    - omi_psrp_server_is_installed.rc == 1
+
+- name: download latest omi psrp server releases
+  get_url:
+    url: "https://github.com{{ omi_psrp_server_releases.stdout_lines[0] }}"
+    dest: /tmp/omi_psrp_server.deb
+  register: omi_psrp_server_download
+  when:
+    - pwsh_install_omi|default(false)
+    - omi_psrp_server_is_installed.rc == 1
+    - ansible_lsb.codename != "xenial"
+
+- name: install omi psrp server
+  apt:
+    deb: "/tmp/omi_psrp_server.deb"
+  when:
+    - pwsh_install_omi|default(false)
+    - omi_psrp_server_is_installed.rc == 1
+    - omi_psrp_server_download.changed
+    - ansible_lsb.codename != "xenial"
+
+- name: clean omi psrp server download
+  file:
+    path: /tmp/omi_psrp_server.deb
+    state: absent
+
+- name: install pwsh omi and remoting
   apt:
     name: "{{ item }}"
     state: present
   with_items:
-  - omi
-  - omi-psrp-server
+    - omi
+    - omi-psrp-server
+  when:
+    - pwsh_install_omi|default(false)
+    - ansible_lsb.codename == "xenial"

--- a/tasks/os_Debian.yml
+++ b/tasks/os_Debian.yml
@@ -29,9 +29,10 @@
     - gawk
     - apt-transport-https
 
-- name: set gpg key
+- name: install powershell gpg key
   apt_key:
-    url: "https://packages.microsoft.com/keys/microsoft.asc"
+    keyserver: packages.microsoft.com
+    id: BC528686B50D79E339D3721CEB3E94ADBE1229CF
     state: present
 
 - name: install azure-cli gpg key

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost
+  tasks:
+    - name: register omi releases
+      shell: curl -sL https://github.com/Microsoft/omi/releases | awk -v ssl_version=ssl_100 '/<a href=(.*deb).*/{if ($0 ~ ssl_version) { match($0,"<a href=.(.*deb).*",matches); print matches[1] }}'
+      register: omi_releases

--- a/test/.travis.yml
+++ b/test/.travis.yml
@@ -1,0 +1,11 @@
+---
+sudo: required
+# docker is required to run tests
+services: docker
+
+install:
+  - bundle install
+
+script:
+  # run kitchen tests (destroy, create, converge, setup, verify and destroy)
+  - bundle exec kitchen test

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -1,0 +1,8 @@
+---
+
+# This playbook deploys the ansible-powershell role for testing.
+
+- hosts: test-kitchen
+  user: root
+  roles:
+    - ansible-powershell

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,32 @@
+require_relative './spec_helper'
+
+describe 'ansible-powershell:default' do
+
+  describe file('/etc/hosts') do
+    it { should be_owned_by('root') }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 644 }
+  end
+
+  describe package('powershell') do
+    it { should be_installed }
+  end
+
+  describe package('azure-cli') do
+    it { should be_installed }
+  end
+
+  describe package('omi') do
+    it { should be_installed }
+  end
+
+  describe package('omi-psrp-server') do
+    it { should be_installed }
+  end
+
+  describe file('/usr/local/share/powershell/Modules/AzureRM.Netcore') do
+    it { should be_directory }
+    it { should exist }
+  end
+
+end

--- a/test/integration/default/serverspec/spec_helper.rb
+++ b/test/integration/default/serverspec/spec_helper.rb
@@ -1,0 +1,9 @@
+require 'serverspec'
+
+set :backend, :exec
+
+RSpec.configure do |c|
+  c.before :all do
+    c.path = '/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin'
+  end
+end


### PR DESCRIPTION
Role would not run on ubuntu 17.10 successfully. I have now fixed that. Additionally, I added azure installation options and made omi optional as well. Furthermore, I added the kitchen-ci framework so that the role can be tested against the following matrix of debian base distributions and versions:

ubuntu 16.04
ubuntu 17.10
debian jessie
debian stretch

You can see an example travis file [here](https://github.com/hurricanehrndz/ansible-sudoers/blob/master/.travis.yml).